### PR TITLE
catch value error during unpickle of test ids

### DIFF
--- a/rednose.py
+++ b/rednose.py
@@ -190,7 +190,7 @@ class ColourTextTestResult(nose.result.TextTestResult):
                 data = load(fh)
 
             return dict((address, _id) for _id, address in data["ids"].items())
-        except IOError:
+        except (IOError, ValueError):
             return {}
 
     def printSummary(self, start, stop):  # noqa


### PR DESCRIPTION
If you run tests on python 2 and python 3, it tries to unpickle the nose test file from python 3 on python 2 and fails. I should just catch that error.