### PR TITLE
Update `nosetests` URL

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -57,4 +57,4 @@ the end, to enable it use::
 
 	nosetests --rednose --immediate
 
-.. _nosetests: http://somethingaboutorange.com/mrl/projects/nose/
+.. _nosetests: https://nose.readthedocs.io/en/latest/index.html


### PR DESCRIPTION
Because `nosetests` is no longer hosted at the domain `somethingaboutorange.com`, which is a content farm these days. PyPI lists the Read The Docs site as the Homepage, and the project description in PyPI links (indirectly) to https://github.com/nose-devs/nose as the repository.